### PR TITLE
Fix bug when dev label contains special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ label("this is my dummy text") # => Compiler error now
 
 # Without the -Denforce_labels flag, the `label` macro returns the string as-is
 label("this is my dummy text") # => "this is my dummy text"
+# NOTE: dummy text should not contain ';' characters, as this will break the compiler check parsing
 
 # RUNTIME CHECKS
 # By default, trying to retrieve a non-existent label doesn't throw

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,6 +13,8 @@ label("You have #{count} apples") # doesn't make sense yet if count == 1
 
 At some point you'll need to set what language / locale the intended user is using, and there are two approachs to doing that. One is by passing in the locale directly to `locale` as the second parameter, or alternatively (and more easily), you can set the locale for the request. The below are equivalent:
 
+NOTE: Free form strings as labels shouldn't contain the semicolon (';') character, as this is used under the hood as a delimiter when enforcing labels with the compiler check. Semicolons can be used freely within label files though.
+
 ```crystal
 label(some.label.path) # no locale set, will resolve from root
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: cr-i18n
-version: 3.1.4
+version: 3.1.5
 
 authors:
   - Troy Sornson <troy@sornson.io>

--- a/spec/label_checker_spec.cr
+++ b/spec/label_checker_spec.cr
@@ -54,6 +54,17 @@ unless_enforce do
         expect(checker(visitors_for("labels.\#{whatever}")).perform_check).to eq [] of String
       end
 
+      it "handles interpolated strings with special characters" do
+        expect(checker(visitors_for("labels.\#{rand > 500 ? \"yes\" : \"no\"}")).perform_check).to eq [] of String
+      end
+
+      it "handles interpolated strings with special characters and label targets with special characters" do
+        expect(checker(visitors_for("\#{somevar?} something else")).perform_check).to eq [
+          "Missing label '\#{somevar?} something else' at filename:4 wasn't found in labels loaded from the_directory",
+          "These labels are defined in the_directory but weren't used and can be removed:\n\tlabels.exists\n\tlabels.other_exists",
+        ]
+      end
+
       it "handles parens in target" do
         expect(checker([visitor_for("(:)")]).perform_check).to eq [
           "Missing label '(:)' at filename:4 wasn't found in labels loaded from the_directory",

--- a/spec/label_checker_spec.cr
+++ b/spec/label_checker_spec.cr
@@ -53,6 +53,20 @@ unless_enforce do
       it "correctly matches interpolated string" do
         expect(checker(visitors_for("labels.\#{whatever}")).perform_check).to eq [] of String
       end
+
+      it "handles parens in target" do
+        expect(checker([visitor_for("(:)")]).perform_check).to eq [
+          "Missing label '(:)' at filename:4 wasn't found in labels loaded from the_directory",
+          "These labels are defined in the_directory but weren't used and can be removed:\n\tlabels.exists\n\tlabels.other_exists",
+        ]
+      end
+
+      it "handles an open paren in target" do
+        expect(checker([visitor_for("(")]).perform_check).to eq [
+          "Missing label '(' at filename:4 wasn't found in labels loaded from the_directory",
+          "These labels are defined in the_directory but weren't used and can be removed:\n\tlabels.exists\n\tlabels.other_exists",
+        ]
+      end
     end
 
     context "with plural labels" do

--- a/src/cr-i18n/macro_runners/label_checker.cr
+++ b/src/cr-i18n/macro_runners/label_checker.cr
@@ -26,6 +26,8 @@ module CrI18n
     end
 
     def resolve_target_to_existing_label_target(subject = target)
+      # A target can contain string interpolated data, so characters #, {, and } are omitted from the below
+      return nil if subject.match(/[\[\]\(\);:\?!@$%^&\*\+ ]/)
       @labels.root_labels.keys.find(&.match(regex_for_target(subject)))
     end
 
@@ -341,7 +343,8 @@ module CrI18n
       return @results if @checked
 
       @visited_labels.each do |label_identifier|
-        @target, @filename, @line_number, @is_plural, @params, @interpolated = label_identifier.split(":")
+        # Only split the last 6 ':', in case the target isn't an actual label target and contains ':' characters
+        @target, @filename, @line_number, @is_plural, @params, @interpolated = label_identifier.reverse.split(/:/, 6).reverse.map(&.reverse)
 
         add_to_verified_root
         check_label_existence

--- a/src/cr-i18n/macro_runners/label_checker.cr
+++ b/src/cr-i18n/macro_runners/label_checker.cr
@@ -26,8 +26,7 @@ module CrI18n
     end
 
     def resolve_target_to_existing_label_target(subject = target)
-      # A target can contain string interpolated data, so characters #, {, and } are omitted from the below
-      return nil if subject.match(/[\[\]\(\);:\?!@$%^&\*\+ ]/)
+      return nil if subject.gsub(/#\{.*?\}/, "").match(/[ !@$%^\+&\*\(\)\[\]]/)
       @labels.root_labels.keys.find(&.match(regex_for_target(subject)))
     end
 


### PR DESCRIPTION
If the `label` macro is used with a free form string before being migrated to a label file, and that free form string contains an open paren by itself, a colon character, or a semi-colon character, it breaks the `-Denforce_labels` check done by the compiler as the `:` and ';' are treated as special, and label targets can be embedded in a regex, which causes an open paren by itself to cause a failure.

Solution: If a label target contains special characters, then don't treat it as a target, treat it as free form text (exceptions being made for `#`, `{`, `}`, and `.`, as these can show up in valid label targets using string interpolation). 